### PR TITLE
Add CI workflow for Java project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up JDK 11
+      uses: actions/setup-java@v2
+      with:
+        java-version: '11'
+
+    - name: Compile TinyEdit.java
+      run: javac TinyEdit.java
+
+    - name: Run TinyEdit
+      run: java TinyEdit
+
+    - name: Check code formatting
+      run: |
+        sudo apt-get install -y openjdk-11-jdk
+        sudo apt-get install -y checkstyle
+        checkstyle -c /google_checks.xml TinyEdit.java
+
+    - name: Lint code
+      run: |
+        sudo apt-get install -y openjdk-11-jdk
+        sudo apt-get install -y checkstyle
+        checkstyle -c /google_checks.xml TinyEdit.java


### PR DESCRIPTION
Add a new GitHub Actions workflow for CI.

* **Workflow Configuration**
  - Trigger on push and pull request events to the main branch
  - Use `ubuntu-latest` as the runner

* **Job Steps**
  - Checkout repository using `actions/checkout@v2`
  - Set up JDK 11 using `actions/setup-java@v2`
  - Compile `TinyEdit.java` using `javac`
  - Run the compiled `TinyEdit` class using `java`
  - Check code formatting using `checkstyle` with Google checks
  - Lint code using `checkstyle` with Google checks

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bingus912/tinyedit/pull/2?shareId=f0190b4c-692c-462b-b8ab-2b48899ba84f).